### PR TITLE
Basic python3 compatibility

### DIFF
--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+from __future__ import print_function
 from HTMLParser import HTMLParser
 from autopkglib import Processor, ProcessorError
 
@@ -32,9 +34,9 @@ class F5transkriptURLProvider(Processor):
             escaped_url = re.search(REGEX, html_source).group(1)
             url = HTMLParser().unescape(escaped_url)
             if self.env["verbose"] > 0:
-                print "F5transkriptURLProvider: Match found is: %s" % escaped_url
-                print "F5transkriptURLProvider: Unescaped url is: %s" % url
-                print "F5transkriptURLProvider: Returning full url: %s%s" % (BASE_URL, url)
+                print("F5transkriptURLProvider: Match found is: %s" % escaped_url)
+                print("F5transkriptURLProvider: Unescaped url is: %s" % url)
+                print("F5transkriptURLProvider: Returning full url: %s%s" % (BASE_URL, url))
         except BaseException as err:
             raise ProcessorError("Failed to get URL: %s" % err)
         self.env["url"] = BASE_URL + url

--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -41,7 +41,7 @@ class F5transkriptURLProvider(Processor):
                 print("F5transkriptURLProvider: Match found is: %s" % escaped_url)
                 print("F5transkriptURLProvider: Unescaped url is: %s" % url)
                 print("F5transkriptURLProvider: Returning full url: %s%s" % (BASE_URL, url))
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Failed to get URL: %s" % err)
         self.env["url"] = BASE_URL + url
 

--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import print_function
-from HTMLParser import HTMLParser
-from autopkglib import Processor, ProcessorError
+from __future__ import absolute_import, print_function
 
 import re
-import urllib2
+from HTMLParser import HTMLParser
+
+from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 
 BASE_URL = "https://www.audiotranskription.de"
@@ -29,7 +33,7 @@ class F5transkriptURLProvider(Processor):
     def main(self):
 
         try:
-            response = urllib2.urlopen(BASE_URL + "/downloads.html")
+            response = urlopen(BASE_URL + "/downloads.html")
             html_source = response.read()
             escaped_url = re.search(REGEX, html_source).group(1)
             url = HTMLParser().unescape(escaped_url)

--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 BASE_URL = "https://www.audiotranskription.de"
-REGEX = 'href="(\/audot\/downloadfile\.php\?.*)">Download für Mac \(f5\)'
+REGEX = r'href="(\/audot\/downloadfile\.php\?.*)">Download für Mac \(f5\)'
 
 __all__ = ["F5transkriptURLProvider"]
 

--- a/JetBrains/IntellijURLProvider.py
+++ b/JetBrains/IntellijURLProvider.py
@@ -8,6 +8,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+from __future__ import absolute_import
 import urllib2
 from xml.dom import minidom
 

--- a/JetBrains/IntellijURLProvider.py
+++ b/JetBrains/IntellijURLProvider.py
@@ -55,7 +55,7 @@ class IntellijURLProvider(Processor):
             f = urlopen(intellij_version_url)
             html = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError(
                 'Can not download %s: %s' % (
                     intellij_version_url, e)

--- a/JetBrains/IntellijURLProvider.py
+++ b/JetBrains/IntellijURLProvider.py
@@ -9,10 +9,15 @@
 #
 
 from __future__ import absolute_import
-import urllib2
+
 from xml.dom import minidom
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["IntellijURLProvider"]
 
@@ -47,8 +52,7 @@ class IntellijURLProvider(Processor):
         """Retrieve version number from XML."""
         # Read XML
         try:
-            req = urllib2.Request(intellij_version_url)
-            f = urllib2.urlopen(req)
+            f = urlopen(intellij_version_url)
             html = f.read()
             f.close()
         except BaseException as e:

--- a/JetBrains/PyCharmURLProvider.py
+++ b/JetBrains/PyCharmURLProvider.py
@@ -10,10 +10,15 @@
 #
 
 from __future__ import absolute_import
-import urllib2
+
 from xml.dom import minidom
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["PyCharmURLProvider"]
 
@@ -48,8 +53,7 @@ class PyCharmURLProvider(Processor):
         """Retrieve version number from XML."""
         # Read XML
         try:
-            req = urllib2.Request(intellij_version_url)
-            f = urllib2.urlopen(req)
+            f = urlopen(intellij_version_url)
             html = f.read()
             f.close()
         except BaseException as e:

--- a/JetBrains/PyCharmURLProvider.py
+++ b/JetBrains/PyCharmURLProvider.py
@@ -56,7 +56,7 @@ class PyCharmURLProvider(Processor):
             f = urlopen(intellij_version_url)
             html = f.read()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError(
                 'Can not download %s: %s' % (
                     intellij_version_url, e)

--- a/JetBrains/PyCharmURLProvider.py
+++ b/JetBrains/PyCharmURLProvider.py
@@ -9,6 +9,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+from __future__ import absolute_import
 import urllib2
 from xml.dom import minidom
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `HTMLParser`), but this should catch the low-hanging fruit right now.