### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/PyMOL/PyMOL.download.recipe
+++ b/PyMOL/PyMOL.download.recipe
@@ -24,7 +24,7 @@
 				<string>https://pymol.org/2/</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -35,7 +35,7 @@
 				<string>%match%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.