### PR TITLE
Autopkg recipes for MAXQDA 12 and 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# .DS_Store files!
+.DS_Store
+
+# don't track .pyc files
+*.pyc

--- a/MAXQDA/maxqda_12.download.recipe
+++ b/MAXQDA/maxqda_12.download.recipe
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download Recipe for the latest version of MAXQDA12 </string>
+    <key>Identifier</key>
+    <string>com.github.its-unibas.download.MAXQDA12</string>
+    <key>Input</key>
+    <dict>
+        <key>VERSION</key>
+        <string>12</string>
+        <key>NAME</key>
+        <string>MAXQDA12</string>
+        <key>URL</key>
+        <string>http://www.maxqda.de/updates/%VERSION%/MAXQDA%VERSION%.dmg</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%URL%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/%NAME%.app</string>
+            </dict>
+            
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MAXQDA/maxqda_12.munki.recipe
+++ b/MAXQDA/maxqda_12.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of MAXQDA12 and imports into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.its-unibas.munki.MAXQDA12</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>MAXQDA12</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>description</key>
+            <string>MAXQDA ist eine Software für qualitative Datenanalyse und Mixed Methods Forschung.</string> 
+            <key>developer</key>
+            <string>VERBI Software GMBH</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>minimum_os_version</key>
+            <string>10.8.0</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>ParentRecipe</key>
+    <string>com.github.its-unibas.download.MAXQDA12</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MAXQDA/maxqda_2018.download.recipe
+++ b/MAXQDA/maxqda_2018.download.recipe
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download Recipe for the latest version of MAXQDA2018 </string>
+    <key>Identifier</key>
+    <string>com.github.its-unibas.download.MAXQDA2018</string>
+    <key>Input</key>
+    <dict>
+        <key>VERSION</key>
+        <string>2018</string>
+        <key>NAME</key>
+        <string>MAXQDA2018</string>
+        <key>URL</key>
+        <string>http://www.maxqda.de/updates/%VERSION%/MAXQDA%VERSION%.dmg</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%URL%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/%NAME%.app</string>
+            </dict>
+            
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MAXQDA/maxqda_2018.munki.recipe
+++ b/MAXQDA/maxqda_2018.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of MAXQDA2018 and imports into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.its-unibas.munki.MAXQDA2018</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>MAXQDA2018</string>
+        <key>MUNI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>description</key>
+            <string>MAXQDA ist eine Software für qualitative Datenanalyse und Mixed Methods Forschung.</string> 
+            <key>developer</key>
+            <string>VERBI Software GMBH</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>minimum_os_version</key>
+            <string>10.9.0</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>ParentRecipe</key>
+    <string>com.github.its-unibas.download.MAXQDA2018</string>
+    <key>Proces</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/MAXQDA/maxqda_2018.munki.recipe
+++ b/MAXQDA/maxqda_2018.munki.recipe
@@ -10,7 +10,7 @@
     <dict>
         <key>NAME</key>
         <string>MAXQDA2018</string>
-        <key>MUNI_REPO_SUBDIR</key>
+        <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>pkginfo</key>
         <dict>
@@ -38,7 +38,7 @@
     <string>0.4.2</string>
     <key>ParentRecipe</key>
     <string>com.github.its-unibas.download.MAXQDA2018</string>
-    <key>Proces</key>
+    <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>


### PR DESCRIPTION
* implemented download recipes for MAXQDA12 and MAXQDA2018 
* implemented munki recipes to import both MAXQDA12 and MAXQDA2018 
also: added a .gitignore file to keep the repository clean. 