### PR TITLE
Unipro ugene

### DIFF
--- a/UniproUgene/unipro_ugene.download.recipe
+++ b/UniproUgene/unipro_ugene.download.recipe
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Download Recipe for the latest version of Unipro Ugene </string>
+    <key>Identifier</key>
+    <string>com.github.its-unibas.download.Unipro_Ugene</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Ugene</string>
+        <key>SEARCH_PATTERN</key>
+        <string>href="(.*ugene\.unipro\.ru\/downloads\/ugene-.*-mac-.*dmg)"</string>
+        <key>SEARCH_URL</key>
+        <string>http://ugene.net/downloads/ugene_get_latest_mac_x86_64.html</string>
+        <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
+        <true />
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>Process</key>
+    <array>
+        <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>re_pattern</key>
+                    <string>%SEARCH_PATTERN%</string>
+                    <key>url</key>
+                    <string>%SEARCH_URL%</string>
+                </dict>
+                <key>Processor</key>
+                <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%match%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/UniproUgene/unipro_ugene.munki.recipe
+++ b/UniproUgene/unipro_ugene.munki.recipe
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of Unipro Ugene and imports into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.its-unibas.munki.Unipro_Ugene</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>UGENE</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>SEARCH_PATTERN2</key>
+        <string>(?&lt;=ugene\.unipro\.ru\/downloads\/ugene-)..\..(?=-mac-x..-64.dmg)</string>
+        <key>SEARCH_URL</key>
+        <string>http://ugene.net/downloads/ugene_get_latest_mac_x86_64.html</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Productivity</string>
+            <key>description</key>
+            <string>UGENE ist eine Open Source Bioinformatik Software, welche als Unterstützung dient beim managen, analysieren und visualisieren von Daten in der Molekularbiologie.</string> 
+            <key>developer</key>
+            <string>Unipro</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>minimum_os_version</key>
+            <string>10.7.0</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.2</string>
+    <key>ParentRecipe</key>
+    <string>com.github.its-unibas.download.Unipro_Ugene</string>
+    <key>Process</key>
+    <array>
+            <dict>
+                    <key>Arguments</key>
+                        <dict>
+                            <key>re_pattern</key>
+                            <string>%SEARCH_PATTERN2%</string>
+                            <key>url</key>
+                            <string>%SEARCH_URL%</string>
+                        </dict>
+                    <key>Processor</key>
+                    <string>URLTextSearcher</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                    <dict>
+                        <key>additional_pkginfo</key>
+                        <dict>
+                            <key>version</key>
+                            <string>%match%</string>
+                        </dict>
+                    </dict>
+                <key>Processor</key>
+                <string>MunkiPkginfoMerger</string>
+            </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/UniproUgene/unipro_ugene.munki.recipe
+++ b/UniproUgene/unipro_ugene.munki.recipe
@@ -13,7 +13,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>SEARCH_PATTERN2</key>
-        <string>(?&lt;=ugene\.unipro\.ru\/downloads\/ugene-)..\..(?=-mac-x..-64.dmg)</string>
+        <string>(?&lt;=ugene\.unipro\.ru\/downloads\/ugene-).*(?=-mac-x..-64.dmg)</string>
         <key>SEARCH_URL</key>
         <string>http://ugene.net/downloads/ugene_get_latest_mac_x86_64.html</string>
         <key>pkginfo</key>


### PR DESCRIPTION
Download und Munki Recipes für Unipro UGENE. 
Musste einen Workaround basteln, damit die richtige Versionsnummer importiert wird. Default mäßig wurde einfach Version 0 importiert und somit wären auch keine Updatesmöglich gewesen. Nun wird über einen URL-TextSearcher aus der URL die Versionsnummer ausgelesen. 