### PR TITLE
Update ants client munki recipe

### DIFF
--- a/ants-framework/ants_client.munki.recipe
+++ b/ants-framework/ants_client.munki.recipe
@@ -73,8 +73,6 @@
 			<string>PathDeleter</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict/>
 			<key>Processor</key>
 			<string>MunkiPkginfoMerger</string>
 		</dict>


### PR DESCRIPTION
AutoPkgr has a problem with this recipe, because a non-optional value is missing in the MunkiPkginfoMerger. If this does not work, the key AdditionalPkgInfo will be added with a value.