### PR TITLE
Fix autopkg recipe for ants-framework

### DIFF
--- a/ants-framework/ants_client.munki.recipe
+++ b/ants-framework/ants_client.munki.recipe
@@ -73,10 +73,6 @@
 			<string>PathDeleter</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-		</dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>


### PR DESCRIPTION
At the moment the MunkiPkginfoMerger requires additional pkginfos as an argument. But the merger itself is not used. Therefore it is removed to work with AutoPkgr.