### PR TITLE
Update Regex for changed Website

### DIFF
--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 BASE_URL = "https://www.audiotranskription.de"
-REGEX = r"href=\"(/audot/downloadfile\.php\?k=1&amp;d=48&amp;l=de&amp;c=j5i99kpxz1)\">Download für Mac \(f5\)"
+REGEX = r"\"(/audot/downloadfile\.php\?k=1\&d=48\&l=de\&c=j5i99kpxz1)\">MAC\ OS\ \(F5\)"
 
 __all__ = ["F5transkriptURLProvider"]
 


### PR DESCRIPTION
The website https://www.audiotranskription.de/downloads changed their Layout. 
I changed the Regex for F5 Transkript Version 7. Now the correct URL will be provided for the Download. 