### PR TITLE
update Code Signature Requirement for Tableau Prep

### DIFF
--- a/TableauPrep/TableauPrep.download.recipe
+++ b/TableauPrep/TableauPrep.download.recipe
@@ -37,7 +37,7 @@
 			<dict>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Tableau Software, Inc. (QJ4XPRK37C)</string>
+					<string>Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
The download Recipe for Tableau Prep needed an update of its Code Signature Requirements. 