### PR TITLE
Update pre-commit config and add AutoPkg-related hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,20 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: 'dc9ed97'  # Use the revision sha / tag you want to point at
+    rev: 'v5.6.4'  # Use the revision sha / tag you want to point at
     hooks:
     - id: isort
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3  # Use the ref you want to point at
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4  # Use the ref you want to point at
     hooks:
     - id: flake8
-      language_version: python2.7
+-   repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.8.0
+    hooks:
+    - id: check-autopkg-recipes
+      args: ['--recipe-prefix', 'com.github.its-unibas.']
+    - id: forbid-autopkg-overrides
+    - id: forbid-autopkg-trust-info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,26 @@
 repos:
--   repo: https://github.com/python/black
-    rev: 20.8b1
+  - repo: https://github.com/python/black
+    rev: '20.8b1'
     hooks:
-    - id: black
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: 'v5.6.4'  # Use the revision sha / tag you want to point at
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: 'v5.6.4'
     hooks:
-    - id: isort
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4  # Use the ref you want to point at
+      - id: isort
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: '3.8.4'
     hooks:
-    - id: flake8
--   repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.8.0
+      - id: flake8
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: 'v1.8.1'
     hooks:
-    - id: check-autopkg-recipes
-    - id: forbid-autopkg-overrides
-    - id: forbid-autopkg-trust-info
+      - id: check-autopkg-recipes
+        args: [
+            '--recipe-prefix',
+            'com.github.its-unibas.',
+            'ch.unibas.its.git.mcs.',
+            # '--strict',
+            '--',
+          ]
+      - id: forbid-autopkg-overrides
+      - id: forbid-autopkg-trust-info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,5 @@ repos:
     rev: v1.8.0
     hooks:
     - id: check-autopkg-recipes
-      args: ['--recipe-prefix', 'com.github.its-unibas.']
     - id: forbid-autopkg-overrides
     - id: forbid-autopkg-trust-info

--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -4,10 +4,9 @@
 from __future__ import absolute_import, print_function
 
 import re
+import sys
 
 from autopkglib import URLGetter
-
-import sys
 
 try:
     # import for Python 3
@@ -18,7 +17,7 @@ except ImportError:
 
 
 BASE_URL = "https://www.audiotranskription.de"
-REGEX = '(/audot/downloadfile\.php\?k=\d\&amp;d=\d{2}\&amp;l=de\&amp;c=.{5,15})\\"\>MAC OS \(F5\) \[v7\]'
+REGEX = r'(/audot/downloadfile\.php\?k=\d\&amp;d=\d{2}\&amp;l=de\&amp;c=.{5,15})\\"\>MAC OS \(F5\) \[v7\]'
 
 __all__ = ["F5transkriptURLProvider"]
 

--- a/JetBrains/IntellijURLProvider.py
+++ b/JetBrains/IntellijURLProvider.py
@@ -10,11 +10,10 @@
 
 from __future__ import absolute_import
 
+import sys
 from xml.dom import minidom
 
-from autopkglib import URLGetter, ProcessorError
-
-import sys
+from autopkglib import ProcessorError, URLGetter
 
 __all__ = ["IntellijURLProvider"]
 

--- a/JetBrains/IntellijUltimate.munki.recipe
+++ b/JetBrains/IntellijUltimate.munki.recipe
@@ -10,12 +10,12 @@
 		<string>IntelliJ IDEA.app</string>
 		<key>CODESIGNATUREREQUIREMENT</key>
 		<string>identifier "com.jetbrains.intellij" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
-		<key>edition</key>
-		<string>U</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/JetBrains/Intellij</string>
 		<key>NAME</key>
 		<string>IntellijUltimate</string>
+		<key>edition</key>
+		<string>U</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -34,5 +34,7 @@
 	</dict>
 	<key>ParentRecipe</key>
 	<string>com.github.its-unibas.munki.Intellij</string>
+	<key>Process</key>
+	<array/>
 </dict>
 </plist>

--- a/JetBrains/PyCharmProfessional.munki.recipe
+++ b/JetBrains/PyCharmProfessional.munki.recipe
@@ -34,5 +34,7 @@
 	</dict>
 	<key>ParentRecipe</key>
 	<string>com.github.its-unibas.munki.PyCharm</string>
+	<key>Process</key>
+	<array/>
 </dict>
 </plist>

--- a/JetBrains/PyCharmURLProvider.py
+++ b/JetBrains/PyCharmURLProvider.py
@@ -11,12 +11,10 @@
 
 from __future__ import absolute_import
 
+import sys
 from xml.dom import minidom
 
-from autopkglib import URLGetter, ProcessorError
-
-import sys
-
+from autopkglib import ProcessorError, URLGetter
 
 __all__ = ["PyCharmURLProvider"]
 


### PR DESCRIPTION
This PR updates the pre-commit configuration and makes it more relevant to AutoPkg recipes by adding some hooks from my pre-commit-macadmin repository.

If you haven't already installed pre-commit, `cd` to this repo and run `brew install pre-commit` and `pre-commit install`.

Once installed, you can perform a manual check of all files with `pre-commit run --all-files`:

```
% pre-commit run --all-files
black....................................................................Passed
isort....................................................................Passed
flake8...................................................................Passed
Check AutoPkg Recipes....................................................Passed
Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
```

Subsequently, these checks will be performed automatically prior to each local commit. No need to run manually.

Thanks for considering!