### PR TITLE
Fix SEARCH_PATTERN key

### DIFF
--- a/Spartan/spartan.download.recipe
+++ b/Spartan/spartan.download.recipe
@@ -13,7 +13,7 @@
 			<key>NAME</key>
 			<string>Spartan</string>
 			<key>SEARCH_PATTERN</key>
-			<string>"(http:\/\/downloads\.wavefun\.com\/Mac\/Spartan..V...\.dmg)".*Macintosh.*v\..\..\..</string>
+			<string>"(https:\/\/downloads\.wavefun\.com\/Mac\/Spartan..V...\.dmg)".*Macintosh.*v\..\..\..</string>
 			<key>SEARCH_URL</key>
 			<string>https://www.wavefun.com/downloads</string>
 		</dict>


### PR DESCRIPTION
The current spartan.download.recipe uses a SEARCH_PATTERN value that doesn't seem to work anymore. After taking a look at the Spartan webpage at https://www.wavefun.com/downloads.
Upon inspection, it seems that the download links now use HTTPS instead of the HTTP found in the current links.

Local tests with the new SEARCH_PATTERN value were succesfull.