### PR TITLE
change regex pattern for switchdrive

### DIFF
--- a/SWITCHdrive/SWITCHdrive.download.recipe
+++ b/SWITCHdrive/SWITCHdrive.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(https://misc.www.switch.ch/drive/SWITCHdrive-[\d.]+pkg)</string>
+				<string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S*\/download).*\s.*OSX</string>
 				<key>url</key>
 				<string>https://help.switch.ch/drive/downloads/</string>
 			</dict>
@@ -31,6 +31,8 @@
 			<dict>
 				<key>url</key>
 				<string>%match%</string>
+				<key>prefetch_filename</key>
+				<string>True</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The Regex Pattern for Switchdrive changed. It needed to be a clear identification for OSX, that's why the regex is a little bit less clear than the last one. 

The tag `prefetch_filename` in URLDownloader is needed so that the downloaded file is stored as pkg and not as a binary file. 
