### PR TITLE
Changes to regexes F5 Transkript

### DIFF
--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -17,7 +17,7 @@ except ImportError:
 
 
 BASE_URL = "https://www.audiotranskription.de"
-REGEX = r'(/audot/downloadfile\.php\?k=\d\&amp;d=\d{2}\&amp;l=de\&amp;c=.{5,15})\"\>MAC OS \(F5\) \[v7\]'
+REGEX = r"(/audot/downloadfile\.php\?k=\d\&amp;d=\d{2}\&amp;l=de\&amp;c=.{5,15})\"\>MAC OS \(F5\) \[v7\]"
 
 __all__ = ["F5transkriptURLProvider"]
 

--- a/F5transkript/F5transkriptURLProvider.py
+++ b/F5transkript/F5transkriptURLProvider.py
@@ -17,7 +17,7 @@ except ImportError:
 
 
 BASE_URL = "https://www.audiotranskription.de"
-REGEX = r'(/audot/downloadfile\.php\?k=\d\&amp;d=\d{2}\&amp;l=de\&amp;c=.{5,15})\\"\>MAC OS \(F5\) \[v7\]'
+REGEX = r'(/audot/downloadfile\.php\?k=\d\&amp;d=\d{2}\&amp;l=de\&amp;c=.{5,15})\"\>MAC OS \(F5\) \[v7\]'
 
 __all__ = ["F5transkriptURLProvider"]
 

--- a/UniproUgene/unipro_ugene.download.recipe
+++ b/UniproUgene/unipro_ugene.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Ugene</string>
         <key>SEARCH_PATTERN</key>
-        <string>href="(.*ugene\.unipro\.ru\/downloads\/packages\/.*\/ugene-.*-mac-.*\.dmg)"</string>
+        <string>href="(https:\/\/github\.com\/ugeneunipro\/ugene\/releases\/download\/\d{2}\.\d\/ugene-\d{2}\.\d-mac-x86-64\.dmg)"</string>
         <key>SEARCH_URL</key>
         <string>http://ugene.net/downloads/ugene_get_latest_mac_x86_64_full.html</string>
         <key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>


### PR DESCRIPTION
## F5 Transkript 
* Through the application of Black to the URL provider the old Regex got invalid. The new Regex holds up with the standards. 
## Unipro Gene
* Regex leading to the new source for the Unipro Ugene on GitHub. 

