### PR TITLE
Fix MinimumVersion key

### DIFF
--- a/CLANc/CLANc.download.recipe
+++ b/CLANc/CLANc.download.recipe
@@ -13,7 +13,7 @@
 			<key>DOWNLOAD_URL</key>
 			<string>https://dali.talkbank.org/clan/clanC.dmg</string>
 		</dict>
-		<key>MiniumumVersion</key>
+		<key>MinimumVersion</key>
 		<string>1.0</string>
 		<key>Process</key>
 		<array>

--- a/Spartan/spartan.download.recipe
+++ b/Spartan/spartan.download.recipe
@@ -17,7 +17,7 @@
 			<key>SEARCH_URL</key>
 			<string>https://www.wavefun.com/downloads</string>
 		</dict>
-		<key>MiniumumVersion</key>
+		<key>MinimumVersion</key>
 		<string>1.0</string>
 		<key>Process</key>
 		<array>

--- a/Spartan/spartan.munki.recipe
+++ b/Spartan/spartan.munki.recipe
@@ -35,7 +35,7 @@
 				<true />
 			</dict>
 		</dict>
-		<key>MiniumumVersion</key>
+		<key>MinimumVersion</key>
 		<string>1.0</string>
 		<key>ParentRecipe</key>
 		<string>com.github.its-unibas.download.spartan</string>


### PR DESCRIPTION
A typo was [found and fixed](https://github.com/autopkg/autopkg/commit/983087f63d49c8dbc4dbbd6bb5ced34321c59ac6) in the template AutoPkg uses when the `autopkg new-recipe` command is used. This PR makes the same change in your recipes that are affected by the typo.