### PR TITLE
Fix SEARCH_STRING variable name

### DIFF
--- a/UniproUgene/unipro_ugene.munki.recipe
+++ b/UniproUgene/unipro_ugene.munki.recipe
@@ -44,7 +44,7 @@
                     <key>Arguments</key>
                         <dict>
                             <key>re_pattern</key>
-                            <string>%SEARCH_PATTERN2%</string>
+                            <string>%SEARCH_PATTERN%</string>
                             <key>url</key>
                             <string>%SEARCH_URL%</string>
                         </dict>


### PR DESCRIPTION
This PR fixes the error "URLTextSearcher: Use of undefined key in variable substitution: 'SEARCH_PATTERN2'", 
by changing the variable name, as in previous commits the variable definition has been deleted from the .munki recipe and there is now a SEARCH_PATTERN recipe in the .download recipe.
The recipe has been tested and now runs as expected.