### PR TITLE
[ITSCS-3091] Add depreciation warning for f4transkript recipes

### DIFF
--- a/F5transkript/F5transkript.download.recipe
+++ b/F5transkript/F5transkript.download.recipe
@@ -17,6 +17,24 @@
 	<array>
 		<dict>
 			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>f5transkript has been replaced by the developer with f4transkript. This recipe is now non-functional. Please remove it from your list of recipes.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>TRUEPREDICATE</string>
+			</dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
 			<dict/>
 			<key>Processor</key>
 			<string>F5transkriptURLProvider</string>


### PR DESCRIPTION
This PR adds the DeprecationWarning processor to the f5transkript.download.recipe saying "f5transkript has been replaced by the developer with f4transkript. This recipe is now non-functional. Please remove it from your list of recipes".
It also adds the StopProcessingIf processor right beneath the DeprecationWarning processor, which stops the execution of any other processors.
This renders all (already failing) recipes non-functional and only returns the DeprecationWarning.