### PR TITLE
UNIPRO UGENE: Change URL Provider to Github Releases

### DIFF
--- a/UniproUgene/unipro_ugene.download.recipe
+++ b/UniproUgene/unipro_ugene.download.recipe
@@ -11,9 +11,9 @@
         <key>NAME</key>
         <string>Ugene</string>
         <key>SEARCH_PATTERN</key>
-        <string>href="(https:\/\/github\.com\/ugeneunipro\/ugene\/releases\/download\/\d{2}\.\d\/ugene-\d{2}\.\d-mac-x86-64\.dmg)"</string>
-        <key>SEARCH_URL</key>
-        <string>http://ugene.net/downloads/ugene_get_latest_mac_x86_64_full.html</string>
+        <string>ugene-.{4,6}-mac-x86-64\.dmg</string>
+        <key>GITHUB_REPO</key>
+        <string>ugeneunipro/ugene</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.2</string>
@@ -25,9 +25,9 @@
             <key>Arguments</key>
             <dict>
                 <key>asset_regex</key>
-                <string>ugene-.{4,6}-mac-x86-64\.dmg</string>
+                <string>%SEARCH_PATTERN%</string>
                 <key>github_repo</key>
-                <string>ugeneunipro/ugene</string>
+                <string>%GITHUB_REPO%</string>
             </dict>
         </dict>
         <dict>

--- a/UniproUgene/unipro_ugene.download.recipe
+++ b/UniproUgene/unipro_ugene.download.recipe
@@ -20,26 +20,24 @@
     <key>Process</key>
     <array>
         <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>re_pattern</key>
-                    <string>%SEARCH_PATTERN%</string>
-                    <key>url</key>
-                    <string>%SEARCH_URL%</string>
-                </dict>
-                <key>Processor</key>
-                <string>URLTextSearcher</string>
-        </dict>
-        <dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>%match%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <key>asset_regex</key>
+                <string>ugene-.{4,6}-mac-x86-64\.dmg</string>
+                <key>github_repo</key>
+                <string>ugeneunipro/ugene</string>
             </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>

--- a/UniproUgene/unipro_ugene.munki.recipe
+++ b/UniproUgene/unipro_ugene.munki.recipe
@@ -40,29 +40,18 @@
     <string>com.github.its-unibas.download.Unipro_Ugene</string>
     <key>Process</key>
     <array>
-            <dict>
-                    <key>Arguments</key>
-                        <dict>
-                            <key>re_pattern</key>
-                            <string>%SEARCH_PATTERN%</string>
-                            <key>url</key>
-                            <string>%SEARCH_URL%</string>
-                        </dict>
-                    <key>Processor</key>
-                    <string>URLTextSearcher</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
+        <dict>
+            <key>Arguments</key>
+                <dict>
+                    <key>additional_pkginfo</key>
                     <dict>
-                        <key>additional_pkginfo</key>
-                        <dict>
-                            <key>version</key>
-                            <string>%match%</string>
-                        </dict>
+                        <key>version</key>
+                        <string>%version%</string>
                     </dict>
-                <key>Processor</key>
-                <string>MunkiPkginfoMerger</string>
-            </dict>
+                </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
To get away from being dependent of a very long and specific regex the infos for the newest version of Unipro Ugene now will be collected via the github releases of the [Unipro Ugene](https://github.com/ugeneunipro/ugene) GitHub Repository. 
I Used the `GithubReleasesInfoProvider` processor like in the [Autopkg Recipe for Autopkg releases](https://github.com/autopkg/recipes/blob/master/AutoPkg/AutoPkg-Release.download.recipe).
