### PR TITLE
Fix PkgPayloadUnpacker processor in .munki recipe

### DIFF
--- a/CLANc/CLANc.munki.recipe
+++ b/CLANc/CLANc.munki.recipe
@@ -61,7 +61,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/pkgpayloadunpacked</string>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpacked/clanc.pkg/Payload</string>
+				<string>%RECIPE_CACHE_DIR%/unpacked/Payload</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgPayloadUnpacker</string>
@@ -70,7 +70,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgpayloadunpacked/CLANc/CLANc.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/pkgpayloadunpacked/CLANc.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>


### PR DESCRIPTION
This PR fixes the CLANc.munki recipe by updating the variables used by the FlatPkgUnpacker processor, reflecting the new structure of the downloaded CLANc installation package.
The recipe in this PR has been tested to work and imports into munki.