### PR TITLE
Update regex pattern

### DIFF
--- a/SWITCHdrive/SWITCHdrive.download.recipe
+++ b/SWITCHdrive/SWITCHdrive.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S*\/download).*\s.*OSX</string>
+				<string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S.*)\">.*Download.*Version.\d.\d.\d.em.</string>
 				<key>url</key>
 				<string>https://help.switch.ch/drive/downloads/</string>
 			</dict>
@@ -30,7 +30,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%match%</string>
+				<string>%match%/download</string>
 				<key>prefetch_filename</key>
 				<string>True</string>
 			</dict>


### PR DESCRIPTION
The HTML makeup of the SWITCHdrive has been altered and as such, the regex search pattern for a download URL had to be modified.

![Screenshot 2021-07-19 at 08 43 24](https://user-images.githubusercontent.com/55440219/126114637-85e04cf7-6829-4422-b59e-1f14bea4b622.png)
![Screenshot 2021-07-19 at 08 43 49](https://user-images.githubusercontent.com/55440219/126114679-f9a21d57-58cd-4b7d-8abb-55fbcb969ada.png)
