### PR TITLE
CorelDRAWUpdate recipes: Compatibility for multiple architectures 

### DIFF
--- a/CorelDRAWUpdate/CorelDRAWUpdate.download.recipe
+++ b/CorelDRAWUpdate/CorelDRAWUpdate.download.recipe
@@ -3,17 +3,19 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Download the latest update for CorelDRAW</string>
+	<string>Download the latest update for CorelDRAW. The base version is modifiable via the BASE_VERSION input variable. The architecture can be chosen from Intel and M1 by modifying the ARCHITECTURE variable.</string>
 	<key>Identifier</key>
 	<string>com.github.its-unibas.download.CorelDRAWUpdate</string>
 	<key>Input</key>
 	<dict>
 		<key>BASE_VERSION</key>
-		<string>2020</string>
+		<string>2021</string>
+		<key>ARCHITECTURE</key>
+		<string>Intel</string>
 		<key>NAME</key>
 		<string>CorelDRAW Update</string>
 		<key>SEARCH_PATTERN</key>
-		<string>href="(.*patches\/CorelDraw\/GraphicsSuite\/%BASE_VERSION%.*dmg)"</string>
+		<string>href="(.*patches\/CorelDraw\/GraphicsSuite\/%BASE_VERSION%\/JRLG\/CDGS%BASE_VERSION%.{2,4}%ARCHITECTURE%\.dmg)"</string>
 		<key>SEARCH_URL</key>
 		<string>https://www.coreldraw.com/de/support/updates/#cdgs-%BASE_VERSION%</string>
 	</dict>

--- a/CorelDRAWUpdate/CorelDRAWUpdate.munki.recipe
+++ b/CorelDRAWUpdate/CorelDRAWUpdate.munki.recipe
@@ -45,7 +45,7 @@
 			<key>display_name</key>
 			<string>CorelDRAW Update</string>
 			<key>name</key>
-			<string>%NAME%%BASE_VERSION%</string>
+			<string>%NAME%%BASE_VERSION%%ARCHITECTURE%</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>update_for</key>

--- a/CorelDRAWUpdate/CorelDRAWUpdate.munki.recipe
+++ b/CorelDRAWUpdate/CorelDRAWUpdate.munki.recipe
@@ -23,7 +23,9 @@
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
-		<string>CorelDRAWUpdate</string>
+		<string>CorelDRAWUpdate%BASE_VERSION% %ARCHITECTURE%</string>
+		<key>UPDATE_FOR</key>
+		<string>%BASE_VERSION_NAME%%BASE_VERSION%</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>blocking_applications</key>
@@ -45,12 +47,12 @@
 			<key>display_name</key>
 			<string>CorelDRAW Update</string>
 			<key>name</key>
-			<string>%NAME%%BASE_VERSION%%ARCHITECTURE%</string>
+			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>update_for</key>
 			<array>
-				<string>%BASE_VERSION_NAME%%BASE_VERSION%</string>
+				<string>%UPDATE_FOR%</string>
 			</array>
 			<key>supported_architectures</key>
 			<array>

--- a/CorelDRAWUpdate/CorelDRAWUpdate.munki.recipe
+++ b/CorelDRAWUpdate/CorelDRAWUpdate.munki.recipe
@@ -5,13 +5,21 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest updates for CorelDRAW and imports it into Munki.</string>
+	<string>Downloads the latest updates for CorelDRAW and imports it into Munki. The base version is modifiable via the BASE_VERSION input variable. 
+		The architecture can be chosen from Intel and M1 by modifying the ARCHITECTURE variable. 
+		Additionally the SUPPORTED_ARCHITECTURE variable has to be adjusted accordingly to x86_64 (Intel) or arm64 (M1)</string>
 	<key>Identifier</key>
 	<string>com.github.its-unibas.munki.CorelDRAWUpdate</string>
 	<key>Input</key>
 	<dict>
 		<key>BASE_VERSION_NAME</key>
-		<string>CorelDRAW Graphics Suite</string>
+		<string>CorelDRAWGraphicsSuite</string>
+		<key>BASE_VERSION</key>
+		<string>2021</string>
+		<key>ARCHITECTURE</key>
+		<string>Intel</string>
+		<key>SUPPORTED_ARCHITECTURE</key>
+		<string>x86_64</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
@@ -37,12 +45,16 @@
 			<key>display_name</key>
 			<string>CorelDRAW Update</string>
 			<key>name</key>
-			<string>%NAME%</string>
+			<string>%NAME%%BASE_VERSION%</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>update_for</key>
 			<array>
-				<string>%BASE_VERSION_NAME%</string>
+				<string>%BASE_VERSION_NAME%%BASE_VERSION%</string>
+			</array>
+			<key>supported_architectures</key>
+			<array>
+				<string>%SUPPORTED_ARCHITECTURE%</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
* changing base version to 2021.
* add `ARCHITECTURE` variable to the download recipe to enable the possibility to choose between downloads for `Intel` and `M1` architectures.
* add `SUPPORTED_ARCHITECTURES` variable to munki recipe to specify the supported architecture for the downloaded software in munki.
* add base version to munki name to avoid confusion with different version. (@aschwanb here I am a little bit torn if this is right here but I think it is the best way to avoid updates from the wrong versions to be installed) 