### PR TITLE
[ITSCS-3807] Add QGIS recipes

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>Downloads the latest version of QGIS, a free and open-source geographic information system</string>
+		<key>Identifier</key>
+		<string>com.github.its-unibas.download.QGIS</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>QGIS</string>
+			<key>DOWNLOAD_URL</key>
+			<string>https://qgis.org/downloads/macos/qgis-macos-pr.dmg</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>1.0</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>url</key>
+					<string>%DOWNLOAD_URL%</string>
+					<key>filename</key>
+					<string>%NAME%.dmg</string>
+				</dict>
+				<key>Processor</key>
+				<string>URLDownloader</string>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -29,6 +29,17 @@
 				<string>URLDownloader</string>
 			</dict>
 			<dict>
+				<key>Arguments</key>
+				<dict>
+					<key>input_path</key>
+					<string>%pathname%/QGIS.app</string>
+					<key>Requirement</key>
+					<string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
+				</dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+			</dict>
+			<dict>
 				<key>Processor</key>
 				<string>EndOfCheckPhase</string>
 			</dict>

--- a/QGIS/QGIS.munki.recipe
+++ b/QGIS/QGIS.munki.recipe
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of QGIS and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.github.its-unibas.munki.QGIS</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_CATEGORY</key>
+		<string>Utility</string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>QGIS</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>%MUNKI_CATEGORY%</string>
+			<key>description</key>
+			<string>QGIS is a free and open-source geographic information system</string>
+			<key>developer</key>
+			<string>QGIS</string>
+			<key>display_name</key>
+			<string>QGIS</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.6.1</string>
+	<key>ParentRecipe</key>
+	<string>com.github.its-unibas.download.QGIS</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/QGIS.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds the .download and .munki recipes for QGIS which download the latest version of QGIS and imports them into Munki.
The recipes have been tested with munki and the software which is installed is functional.