### PR TITLE
fix for current version of SWITCHdrive

### DIFF
--- a/SWITCHdrive/SWITCHdrive.download.recipe
+++ b/SWITCHdrive/SWITCHdrive.download.recipe
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>Description</key>
-	<string>Find and download the newest version of SWITCHdrive</string>
-	<key>Identifier</key>
-	<string>com.github.its-unibas.download.switchdrive</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>SWITCHdrive</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.3.1</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S.*)\">.*Download.*Version.\d.\d.\d.em.</string>
-				<key>url</key>
-				<string>https://help.switch.ch/drive/downloads/</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>%match%</string>
-				<key>prefetch_filename</key>
-				<string>True</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: ownCloud GmbH (4AP2STM4H5)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-				<key>input_path</key>
-				<string>%pathname%</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-	</array>
-</dict>
+    <dict>
+        <key>Description</key>
+        <string>Find and download the newest version of SWITCHdrive</string>
+        <key>Identifier</key>
+        <string>com.github.its-unibas.download.switchdrive</string>
+        <key>Input</key>
+        <dict>
+            <key>NAME</key>
+            <string>SWITCHdrive</string>
+        </dict>
+        <key>MinimumVersion</key>
+        <string>0.3.1</string>
+        <key>Process</key>
+        <array>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>re_pattern</key>
+                    <string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S.*)\">.*Download.*current\ Version.\d*.\d*.\d*.em.</string>
+                    <key>url</key>
+                    <string>https://help.switch.ch/drive/downloads/</string>
+                </dict>
+                <key>Processor</key>
+                <string>URLTextSearcher</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>url</key>
+                    <string>%match%</string>
+                    <key>prefetch_filename</key>
+                    <string>True</string>
+                </dict>
+                <key>Processor</key>
+                <string>URLDownloader</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
+                    <key>expected_authority_names</key>
+                    <array>
+                        <string>Developer ID Installer: ownCloud GmbH (4AP2STM4H5)</string>
+                        <string>Developer ID Certification Authority</string>
+                        <string>Apple Root CA</string>
+                    </array>
+                    <key>input_path</key>
+                    <string>%pathname%</string>
+                </dict>
+                <key>Processor</key>
+                <string>CodeSignatureVerifier</string>
+            </dict>
+        </array>
+    </dict>
 </plist>


### PR DESCRIPTION
Hi folks, I noticed that the SWITCHdrive.download recipe was not grabbing the latest version. The download page has two links, one for current and one for previous, but your regex perhaps predates this and was grabbing the previous version. Additionally, since the version number got to 2.10.x, the regex there didn't match either. I've allowed for multiple characters in the decimals now.

Tested working with the current version.