### PR TITLE
New Code Signature Requirement for PyCharm

### DIFF
--- a/JetBrains/PyCharm.download.recipe
+++ b/JetBrains/PyCharm.download.recipe
@@ -15,7 +15,7 @@
         <key>CODESIGNATUREAPPNAME</key>
         <string>PyCharm CE.app</string>
         <key>CODESIGNATUREREQUIREMENT</key>
-        <string>identifier "com.jetbrains.pycharm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
+        <string>identifier "com.jetbrains.pycharm.ce" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.0</string>


### PR DESCRIPTION
JetBrains has changed the identifier for PyCharm CE which is currently causing the Code Signature Requirement to fail in autopkg runs.