### PR TITLE
modernize maple update url provider

### DIFF
--- a/Maple/MapleUpdateURLProvider.py
+++ b/Maple/MapleUpdateURLProvider.py
@@ -6,7 +6,7 @@ from urllib import response
 
 from autopkglib import URLGetter
 
-from html.parser import HTMLParser
+import html
 
 BASE_URL = 'https://www.maplesoft.com/support/downloads/'
 BASE_URL2 = 'https://www.maplesoft.com/downloads/'
@@ -31,10 +31,10 @@ class MapleUpdateURLProvider(URLGetter):
         response = re.search(REGEX1.format(self.env.get("MajorVersion","2021")), html_source)
         escaped_url = response.group(1)
         version = response.group(2)
-        url = HTMLParser().unescape(escaped_url)
+        url = html.unescape(escaped_url)
         html_source2 = self.download(BASE_URL + url).decode("utf-8")
         final_url = re.search(REGEX2.format(self.env.get("MajorVersion",'2021')), html_source2).group(1)
-        url2 = HTMLParser().unescape(final_url)
+        url2 = html.unescape(final_url)
         if self.env["verbose"] > 0:
             print("MapleUpdateURLProvider: Match found is: {}\n".format(final_url))
             print("MapleUpdateURLProvider: Unescaped url is: {}\n".format(url2))


### PR DESCRIPTION
Change in the URL provider to get the `html.unescape()` method from the right place. 

Output for `autopkg run -vv com.github.its-unibas.download.MapleUpdate`:
```
Processing com.github.its-unibas.download.MapleUpdate...
WARNING: com.github.its-unibas.download.MapleUpdate is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MapleUpdateURLProvider
{'Input': {'MajorVersion': '2021'}}
MapleUpdateURLProvider: Match found is: ?d=DE97B4291AA53C074D2FD61D9E4A9ABA&pr=Maple2021.2.1UpdateInstallers

MapleUpdateURLProvider: Unescaped url is: ?d=DE97B4291AA53C074D2FD61D9E4A9ABA&pr=Maple2021.2.1UpdateInstallers

MapleUpdateURLProvider: Returning full url: https://www.maplesoft.com/downloads/?d=DE97B4291AA53C074D2FD61D9E4A9ABA&pr=Maple2021.2.1UpdateInstallers
{'Output': {'url': 'https://www.maplesoft.com/downloads/?d=DE97B4291AA53C074D2FD61D9E4A9ABA&pr=Maple2021.2.1UpdateInstallers'}}
URLDownloader
{'Input': {'filename': 'MapleUpdate.dmg',
           'url': 'https://www.maplesoft.com/downloads/?d=DE97B4291AA53C074D2FD61D9E4A9ABA&pr=Maple2021.2.1UpdateInstallers'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 08 Feb 2022 18:52:13 GMT
URLDownloader: Storing new ETag header: "309eef7d6ea0dbd6ab1d228ad71aba53"
URLDownloader: Downloaded /Users/user/Library/AutoPkg/Cache/com.github.its-unibas.download.MapleUpdate/downloads/MapleUpdate.dmg
{'Output': {'download_changed': True,
            'etag': '"309eef7d6ea0dbd6ab1d228ad71aba53"',
            'last_modified': 'Tue, 08 Feb 2022 18:52:13 GMT',
            'pathname': '/Users/user/Library/AutoPkg/Cache/com.github.its-unibas.download.MapleUpdate/downloads/MapleUpdate.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/user/Library/AutoPkg/Cache/com.github.its-unibas.download.MapleUpdate/downloads/MapleUpdate.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/user/Library/AutoPkg/Cache/com.github.its-unibas.download.MapleUpdate/receipts/com.github.its-unibas.download-receipt-20220923-114341.plist

The following new items were downloaded:
    Download Path                                                                                               
    -------------                                                                                               
    /Users/user/Library/AutoPkg/Cache/com.github.its-unibas.download.MapleUpdate/downloads/MapleUpdate.dmg 
```