### PR TITLE
Update flake8 URL in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
     rev: 'v5.6.4'
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.4'
+  - repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
     hooks:
       - id: flake8
   - repo: https://github.com/homebysix/pre-commit-macadmin


### PR DESCRIPTION
The flake8 pre-commit hook URL has changed (see PyCQA/flake8#1737). This PR makes the needed adjustment to the pre-commit config.