### PR TITLE
Update TableauPrep.munki.recipe

### DIFF
--- a/TableauPrep/TableauPrep.munki.recipe
+++ b/TableauPrep/TableauPrep.munki.recipe
@@ -3,12 +3,16 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads latest Tableau Prep disk image and imports into Munki.</string>
+	<string>Downloads latest Tableau Prep disk image and imports into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>ch.unibas.its.git.mcs.munki.tableau-prep</string>
 	<key>Input</key>
 	<dict>
-        <key>NAME</key>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
+		<key>NAME</key>
 		<string>TableauPrep</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
@@ -52,7 +56,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>ch.unibas.its.git.mcs.download.tableau-prep</string>
 	<key>Process</key>
@@ -74,7 +78,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
 				<key>pkg_payload_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack/Tableau App.pkg/payload</string>
 				<key>purge_destination</key>
@@ -87,10 +91,31 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Tableau*.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Tableau*.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>
+		</dict>
+		 <dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/%found_basename%</string>
+				</array>
+				<key>version_comparison_key</key>
+				<string>CFBundleShortVersionString</string>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -128,6 +153,18 @@
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Hi, @its-unibas-recipes

The TableauPrep Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in `MunkiInstallsItemsCreator` with support for the new `derive_minimum_os_version` key in the processor. With this set the `min_os_version` becomes 10.11.0

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

`PathDeleter` has also been added to tidy up after.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/its-unibas-recipes/TableauPrep/TableauPrep.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/its-unibas-recipes/TableauPrep/TableauPrep.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/its-unibas-recipes/TableauPrep/TableauPrep.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 13 Dec 2022 23:15:29 GMT
URLDownloader: Storing new ETag header: "ec3b8264787b0e5cc44ed865510ec16c:1670973334.662564"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Tableau Prep Builder.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-11-02 00:15:28 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)
CodeSignatureVerifier:        Expires: 2025-05-30 14:49:09 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            A8 6F 53 17 62 1F D4 C7 F5 1B 2A 5A 9C 2A 1B B9 29 AF B3 79 DF 18 
CodeSignatureVerifier:            48 1D 35 5A EE 9F 21 02 EC 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.j4zm7e/Tableau Prep Builder.pkg to /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack/Tableau App.pkg/payload to /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/TableauPrep/Applications
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/TableauPrep/Applications/Tableau Prep Builder 2022.4.app' from globbed '/Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/TableauPrep/Applications/Tableau*.app'
FileFinder: Basename match: 'Tableau Prep Builder 2022.4.app'
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Tableau Prep Builder 2022.4.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.11.0
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.tableausoftware.tableauprep', 'CFBundleName': 'Tableau Prep Builder', 'CFBundleShortVersionString': '2022.4.0', 'CFBundleVersion': '22.40.22.1101.1638', 'minosversion': '10.11.0', 'path': '/Applications/Tableau Prep Builder 2022.4.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.11.0'} into pkginfo
PlistReader
PlistReader: Reading: /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/TableauPrep/Applications/Tableau Prep Builder 2022.4.app/Contents/Info.plist
PlistReader: Assigning value of '2022.4.0' to output variable 'version'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2022.4.0'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/TableauPrep/TableauPrep-2022.4.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/TableauPrep/TableauPrep-2022.4.0.dmg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/TableauPrep
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack
Receipt written to /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/receipts/TableauPrep.munki-receipt-20230117-120941.plist

The following new items were downloaded:
    Download Path                                                                                         
    -------------                                                                                         
    /Users/paul/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg  

The following new items were imported into Munki:
    Name         Version   Catalogs  Pkginfo Path                                 Pkg Repo Path                              Icon Repo Path  
    ----         -------   --------  ------------                                 -------------                              --------------  
    TableauPrep  2022.4.0  testing   apps/TableauPrep/TableauPrep-2022.4.0.plist  apps/TableauPrep/TableauPrep-2022.4.0.dmg
```
