### PR TITLE
Update FlowJo.munki.recipe

### DIFF
--- a/FlowJo/FlowJo.munki.recipe
+++ b/FlowJo/FlowJo.munki.recipe
@@ -27,8 +27,6 @@
 			<string>FlowJo</string>
 			<key>display_name</key>
 			<string>FlowJo</string>
-			<key>minimum_os_version</key>
-			<string>10.7</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -74,6 +72,31 @@ rm -rf "/Applications/Plugins for FlowJo"
 	<string>com.github.its-unibas.download.FlowJo</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>.*\n*v10 Requirements.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*MacOS ([0-9]*\.[0-9]+)</string>
+                <key>result_output_var_name</key>
+                <string>min_os_ver</string>
+                <key>url</key>
+                <string>https://www.flowjo.com/solutions/flowjo/downloads/previous-versions</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+        </dict>
+        <dict>
+             <key>Arguments</key>
+             <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_ver%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Hi, 

The FlowJo.app doesn't provide the Minimum OS Version with the App's info.plist, and has to be set manually in the recipe override.

This PR adds in URLTextSearcher to grab the minimum_os_version from the vendors website. 

Output from a successful run

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/its-unibas-recipes/FlowJo/FlowJo.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/its-unibas-recipes/FlowJo/FlowJo.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/its-unibas-recipes/FlowJo/FlowJo.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://fjinstallers.s3.amazonaws.com/FlowJo/FlowJo-OSX64-10.9.0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 08 May 2023 20:11:19 GMT
URLDownloader: Storing new ETag header: "947fc8edffb82d924ff8f186152bbba4-20"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/downloads/FlowJo.dmg
EndOfCheckPhase
URLTextSearcher
URLTextSearcher: Found matching text (min_os_ver): 10.11
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.11'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/FlowJo/FlowJo-10.9.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/FlowJo/FlowJo-10.9.0.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/receipts/FlowJo.munki-receipt-20230602-125544.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    /Users/paul/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/downloads/FlowJo.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                     Pkg Repo Path                  Icon Repo Path  
    ----    -------  --------  ------------                     -------------                  --------------  
    FlowJo  10.9.0   testing   apps/FlowJo/FlowJo-10.9.0.plist  apps/FlowJo/FlowJo-10.9.0.dmg
```