### PR TITLE
Add option for ARM / Intel switchdrive download

### DIFF
--- a/SWITCHdrive/SWITCHdrive.download.recipe
+++ b/SWITCHdrive/SWITCHdrive.download.recipe
@@ -1,61 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>Description</key>
-        <string>Find and download the newest version of SWITCHdrive</string>
-        <key>Identifier</key>
-        <string>com.github.its-unibas.download.switchdrive</string>
-        <key>Input</key>
-        <dict>
-            <key>NAME</key>
-            <string>SWITCHdrive</string>
-        </dict>
-        <key>MinimumVersion</key>
-        <string>0.3.1</string>
-        <key>Process</key>
-        <array>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>re_pattern</key>
-                    <string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S.*)\">.*Download.*current\ Version.\d*\.\d*\.\d*.em.</string>
-                    <key>url</key>
-                    <string>https://help.switch.ch/drive/downloads/</string>
-                </dict>
-                <key>Processor</key>
-                <string>URLTextSearcher</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>url</key>
-                    <string>%match%</string>
-                    <key>prefetch_filename</key>
-                    <string>True</string>
-                </dict>
-                <key>Processor</key>
-                <string>URLDownloader</string>
-            </dict>
-            <dict>
-                <key>Processor</key>
-                <string>EndOfCheckPhase</string>
-            </dict>
-            <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>expected_authority_names</key>
-                    <array>
-                        <string>Developer ID Installer: ownCloud GmbH (4AP2STM4H5)</string>
-                        <string>Developer ID Certification Authority</string>
-                        <string>Apple Root CA</string>
-                    </array>
-                    <key>input_path</key>
-                    <string>%pathname%</string>
-                </dict>
-                <key>Processor</key>
-                <string>CodeSignatureVerifier</string>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>Description</key>
+	<string>Specify ARCH to be "ARM" or "Intel". Find and download the newest version of SWITCHdrive</string>
+	<key>Identifier</key>
+	<string>com.github.its-unibas.download.switchdrive</string>
+	<key>Input</key>
+	<dict>
+		<key>ARCH</key>
+		<string>ARM</string>
+		<key>NAME</key>
+		<string>SWITCHdrive</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>(https:\/\/drive\.switch\.ch\/index\.php\/s\/\S.*)\"&gt;Download Sync Client for Mac \(%ARCH%\)</string>
+				<key>url</key>
+				<string>https://help.switch.ch/drive/downloads/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>prefetch_filename</key>
+				<string>True</string>
+				<key>url</key>
+				<string>%match%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: ownCloud GmbH (4AP2STM4H5)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/SWITCHdrive/SWITCHdrive.munki.recipe
+++ b/SWITCHdrive/SWITCHdrive.munki.recipe
@@ -3,11 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of SWITCHDrive and imports it into Munki.</string>
+	<string>Specify ARCH to be "ARM" or "Intel". Downloads the current release version of SWITCHDrive and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.its-unibas.munki.switchdrive</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>ARM</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Storage</string>
 		<key>MUNKI_REPO_SUBDIR</key>


### PR DESCRIPTION
I'm sorry, my formatter ruined the diff. 

The changes are:
- Add Input Variable 'ARCH' in munki and download recipe
- Adapted re_pattern in download recipe to use the 'ARCH' variable
- Change 'Description' in munki and download recipe to highlight the new variable