### PR TITLE
Remove version from f4transkript appname

### DIFF
--- a/F4transkript/f4transkript.download.recipe
+++ b/F4transkript/f4transkript.download.recipe
@@ -8,13 +8,11 @@
 	<string>com.github.its-unibas.download.f4transkript</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>f4transkript</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://www.audiotranskription.de/en/downloads/</string>
-		<!--<string>https://www.audiotranskription.de/en//?smd_process_download=1&amp;download_id=2544</string>-->
+		<key>NAME</key>
+		<string>f4transkript</string>
 		<key>REGEX</key>
-		<!--<string>^.*href=\"(.*download_id=[0-9]*)\".*title=\"f4transkript macOS\".*$</string>-->
 		<string>id=(\d\d\d\d).*title="f4transkript\smacOS</string>
 	</dict>
 	<key>MinimumVersion</key>
@@ -44,20 +42,40 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/f4transkript/f4transkript.app</string>
-                <key>requirement</key>
-                  <string>identifier "de.audiotranskription.F5" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HBM3S22B4A</string>
-            </dict>
-        </dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/f4transkript/f4transkript*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>source</key>
+				<string>%found_filename%</string>
+				<key>target</key>
+				<string>%RECIPE_CACHE_DIR%/f4transkript/f4transkript.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileMover</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/f4transkript/f4transkript.app</string>
+				<key>requirement</key>
+				<string>identifier "de.audiotranskription.F5" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HBM3S22B4A</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Ich entferne die Version aus dem F4Transkript Appname, da wir sie nicht im Namen brauchen und damit die Code Verification wieder funktioniert.