### PR TITLE
Update REGEX and Code Signature of f4transkript recipe

### DIFF
--- a/F4transkript/f4transkript.download.recipe
+++ b/F4transkript/f4transkript.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>f4transkript</string>
 		<key>REGEX</key>
-		<string>id=(\d\d\d\d).*title="f4transkript\smacOS</string>
+		<string>https:\/\/download.audiotranskription.de\/f4-\d+.\d+.\d+-mac\.zip</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.5.0</string>
@@ -33,15 +33,18 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>https://www.audiotranskription.de/en//?smd_process_download=1&amp;download_id=%match%</string>
+				<string>%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+			</dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>
@@ -49,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pattern</key>
-				<string>%RECIPE_CACHE_DIR%/f4transkript/f4transkript*.app</string>
+				<string>%RECIPE_CACHE_DIR%/f4transkript/f4*.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileFinder</string>
@@ -71,7 +74,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/f4transkript/f4transkript.app</string>
 				<key>requirement</key>
-				<string>identifier "de.audiotranskription.F5" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HBM3S22B4A</string>
+				<string>identifier "de.audiotranskription.f4" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = L3Y9ZR6QBW</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Following changes were made:
- Update download regex
- update globbing pattern (app is called f4.app now instead of f4transkript-%version%.app)
- update code signature (before they used f5 for the f4 signature?)