### PR TITLE
VERSION key removed

### DIFF
--- a/MAXQDA/maxqda.download.recipe
+++ b/MAXQDA/maxqda.download.recipe
@@ -3,10 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Download Recipe for the latest version of MAXQDA
-            If you want to download another version of MAXQDA just change VERSION to the specific version Number. Then the download link will be switched out to the specific version. 
-            At the moment it works with the versions 12, 2018, 2020, 2022, 24.
-    </string>
+	<string>Download Recipe for the latest version of MAXQDA.</string>
 	<key>Identifier</key>
 	<string>com.github.its-unibas.download.MAXQDA</string>
 	<key>Input</key>
@@ -15,8 +12,6 @@
 		<string>MAXQDA</string>
 		<key>URL</key>
 		<string>https://www.maxqda.com/download/maxqdademo-mac</string>
-		<key>VERSION</key>
-		<string>24</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>
@@ -41,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%%VERSION%.app</string>
+				<string>%pathname%/%NAME%*.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/MAXQDA/maxqda.munki.recipe
+++ b/MAXQDA/maxqda.munki.recipe
@@ -3,10 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of MAXQDA and imports into Munki. 
-        If you want to download another version of MAXQDA just change VERSION to the specific version Number. Then the download link will be switched out to the specific version. 
-        At the moment it works with the versions 12, 2018, 2020, 2022, 24.
-    </string>
+	<string>Downloads the latest version of MAXQDA and imports into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.its-unibas.munki.MAXQDA</string>
 	<key>Input</key>
@@ -28,11 +25,11 @@
 			<key>developer</key>
 			<string>VERBI Software GMBH</string>
 			<key>display_name</key>
-			<string>%NAME%%VERSION%</string>
+			<string>%NAME%</string>
 			<key>minimum_os_version</key>
 			<string>10.12.0</string>
 			<key>name</key>
-			<string>%NAME%%VERSION%</string>
+			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Changes in the download recipe:
- Change of description to remove VERSION specification 
- removal of VERSION key
- input_path in CodeSignatureVerification no longer VERSION dependent

Changes in the munki recipe:
- Change of description to remove VERSION specification 
- removal of the VERSION in both name and display_name