### PR TITLE
Deprecate erase-install recipes

### DIFF
--- a/erase-install/erase-install.download.recipe
+++ b/erase-install/erase-install.download.recipe
@@ -16,9 +16,18 @@
         <string>grahampugh/erase-install</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.2</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the erase-install recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>

--- a/erase-install/erase-install.munki.recipe
+++ b/erase-install/erase-install.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>0.4.2</string>
     <key>ParentRecipe</key>
-    <string>com.github.its-unibas.download.erase-install</string>
+    <string>com.github.grahampugh.recipes.download.erase-install</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
To simplify recipe searches, this PR deprecates the erase-install download recipe in this repo, which is insufficiently distinct from the one in the grahampugh-recipes repo to justify the additional maintenance effort.

The erase-install munki recipe has been modified to use the grahampugh-recipes download recipe as its parent.
