### PR TITLE
Deprecate QGIS recipes

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -14,9 +14,18 @@
 			<string>https://qgis.org/downloads/macos/qgis-macos-pr.dmg</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>1.0</string>
+		<string>1.1</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>Consider switching to the QGIS download or pkg recipes in the mlbz521-recipes repo or the QGIS munki recipe in the robperc-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<dict>
 				<key>Arguments</key>
 				<dict>
@@ -29,6 +38,10 @@
 				<string>URLDownloader</string>
 			</dict>
 			<dict>
+				<key>Processor</key>
+				<string>EndOfCheckPhase</string>
+			</dict>
+			<dict>
 				<key>Arguments</key>
 				<dict>
 					<key>input_path</key>
@@ -38,10 +51,6 @@
 				</dict>
 				<key>Processor</key>
 				<string>CodeSignatureVerifier</string>
-			</dict>
-			<dict>
-				<key>Processor</key>
-				<string>EndOfCheckPhase</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
The QGIS recipes in this repository are not sufficiently distinct from other recipes in the AutoPkg org to warrant the extra maintenance they will require. This PR deprecates the QGIS recipes in this repo and points users to specific alternatives in other repos.