### PR TITLE
Fix code signature verification in Maxqda recipe

### DIFF
--- a/MAXQDA/maxqda.download.recipe
+++ b/MAXQDA/maxqda.download.recipe
@@ -37,6 +37,8 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/%NAME%*.app</string>
+				<key>requirement</key>
+				<string>identifier "de.verbi.MAXQDA24" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7ME932KUT6"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This PR adds the missing code signature verification requirement for Maxqda.

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.its-unibas.download.MAXQDA/downloads/MAXQDA.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.xE2aLj/MAXQDA24.app' matched from globbed '/private/tmp/dmg.xE2aLj/MAXQDA*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.xE2aLj/MAXQDA24.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.xE2aLj/MAXQDA24.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.xE2aLj/MAXQDA24.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```