### PR TITLE
Update FlowJo.munki.recipe

### DIFF
--- a/FlowJo/FlowJo.munki.recipe
+++ b/FlowJo/FlowJo.munki.recipe
@@ -76,11 +76,11 @@ rm -rf "/Applications/Plugins for FlowJo"
             <key>Arguments</key>
             <dict>
                 <key>re_pattern</key>
-                <string>.*\n*v10 Requirements.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*.*\n*MacOS ([0-9]*\.[0-9]+)</string>
+                <string>OS X ([0-9]+(\.[0-9]+)+) or later</string>
                 <key>result_output_var_name</key>
                 <string>min_os_ver</string>
                 <key>url</key>
-                <string>https://www.flowjo.com/solutions/flowjo/downloads/previous-versions</string>
+                <string>https://flowjo.com/flowjo/download</string>
             </dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
Hi, Folks

FlowJo is currently failing with 
```
Processor: URLTextSearcher: Error: No match found on URL: https://www.flowjo.com/solutions/flowjo/downloads
```

This PR has updated regex and search URL for grabbing the `minimum_os_version`

Output from a successful -v run
```
autopkg run -v FlowJo.munki.recipe 
Looking for com.github.its-unibas.download.FlowJo...
Did not find com.github.its-unibas.download.FlowJo in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.its-unibas.download.FlowJo...
Found com.github.its-unibas.download.FlowJo in recipe map
**load_recipe time: 0.010915333004959393
Processing FlowJo.munki.recipe...
WARNING: FlowJo.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://fjinstallers.s3.amazonaws.com/FlowJo/FlowJo-OSX64-10.10.0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 16 Nov 2023 17:34:31 GMT
URLDownloader: Storing new ETag header: "5c0403dba7ef77760299305f290c58fe-25"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/downloads/FlowJo.dmg
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/downloads/FlowJo.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uwNo2i/FlowJo.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uwNo2i/FlowJo.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uwNo2i/FlowJo.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
EndOfCheckPhase
URLTextSearcher
URLTextSearcher: Found matching text (min_os_ver): 10.9
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.9'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/FlowJo/FlowJo-10.10.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/FlowJo/FlowJo-10.10.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/receipts/FlowJo.munki-receipt-20250220-110850.plist

The following new items were downloaded:
    Download Path                                                                                     
    -------------                                                                                     
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.its-unibas.munki.FlowJo/downloads/FlowJo.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                      Pkg Repo Path                   Icon Repo Path  
    ----    -------  --------  ------------                      -------------                   --------------  
    FlowJo  10.10.0  testing   apps/FlowJo/FlowJo-10.10.0.plist  apps/FlowJo/FlowJo-10.10.0.dmg
```