### PR TITLE
Update FlowJo.download.recipe

### DIFF
--- a/FlowJo/FlowJo.download.recipe
+++ b/FlowJo/FlowJo.download.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/FlowJo.app</string>
+                <string>%pathname%/FlowJo*.app</string>
                 <key>requirement</key>
                 <string>identifier "com.flowjo.flowjo" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = C79HU5AD9V</string>
             </dict>


### PR DESCRIPTION
Apologies - they've also changed the app name to include the version so a wildcard needs to be added into the path for the app in the CodeVerification.