### PR TITLE
FlowJo.munki.recipe is deprecated and will be removed

### DIFF
--- a/FlowJo/FlowJo.munki.recipe
+++ b/FlowJo/FlowJo.munki.recipe
@@ -72,6 +72,15 @@ rm -rf "/Applications/Plugins for FlowJo"
 	<string>com.github.its-unibas.download.FlowJo</string>
 	<key>Process</key>
 	<array>
+		<dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and will be removed in the future. Consider switching to another FlowJo recipe or create a local recipe. The .download recipe will not be removed.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
The [.munki recipe](https://github.com/autopkg/its-unibas-recipes/blob/master/FlowJo/FlowJo.munki.recipe) is no longer used by us, and will therefore be removed.
The [.download recipe](https://github.com/autopkg/its-unibas-recipes/blob/master/FlowJo/FlowJo.download.recipe) will not be removed. 