### PR TITLE
Update recipes for AutoPkg v3.

### DIFF
--- a/QGIS/QGIS.download.recipe
+++ b/QGIS/QGIS.download.recipe
@@ -46,7 +46,7 @@
 				<dict>
 					<key>input_path</key>
 					<string>%pathname%/QGIS*.app</string>
-					<key>Requirement</key>
+					<key>requirement</key>
 					<string>identifier "org.qgis.qgis3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4F7N4UDA22"</string>
 				</dict>
 				<key>Processor</key>


### PR DESCRIPTION
Typo im key requirement gibt ab AutoPkg v3 einen Fehler.